### PR TITLE
build_fix for compilation error-symbol not found

### DIFF
--- a/build-phoenix-ppc64le-hdp25.sh
+++ b/build-phoenix-ppc64le-hdp25.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+HADOOP_VERSION="2.7.3.2.5.0.0-1245"
+HBASE_VERSION="1.1.2.2.5.0.0-1245"
+PIG_VERSION="0.12.0.2.5.0.0-1245"
+FLUME_VERSION="1.5.2.2.5.0.0-1245"
+SPARK_VERSION="1.6.1.2.5.0.0-1245"
+
+mvn -Dhadoop.version=$HADOOP_VERSION  \
+    -Dhadoop-two.version=$HADOOP_VERSION  \
+    -Dhbase.version=$HBASE_VERSION  \
+    -Dpig.version=$PIG_VERSION  \
+    -Dflume.version=$FLUME_VERSION  \
+    -Dspark.version=${SPARK_VERSION} \
+    -DskipTests install "$@"
+rm -rf build
+mkdir build
+
+# Make binary tar
+rm -rf $(find . -type d -name archive-tmp);
+
+#phoenix_jars=$(find -iname phoenix-*.jar)
+#cp $phoenix_jars build/;
+#
+#cp -R bin build/;
+#
+#cp -R phoenix-pherf/config build/bin/
+#
+

--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/Indexer.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/Indexer.java
@@ -271,22 +271,11 @@ public class Indexer extends BaseRegionObserver {
           // get the index updates for all elements in this batch
           Collection<Pair<Mutation, byte[]>> indexUpdates =
                   this.builder.getIndexUpdate(miniBatchOp, mutations.values());
-          Iterator<Pair<Mutation, byte[]>> indexUpdatesItr = indexUpdates.iterator();
-          List<Mutation> localUpdates = new ArrayList<Mutation>(indexUpdates.size());
+          
+          
           current.addTimelineAnnotation("Built index updates, doing preStep");
           TracingUtils.addAnnotation(current, "index update count", indexUpdates.size());
-          while(indexUpdatesItr.hasNext()) {
-              Pair<Mutation, byte[]> next = indexUpdatesItr.next();
-              if (Bytes.compareTo(next.getSecond(), tableName) == 0) {
-                  localUpdates.add(next.getFirst());
-                  indexUpdatesItr.remove();
-              }
-          }
-          if (!localUpdates.isEmpty()) {
-              miniBatchOp.addOperationsFromCP(0,
-                  localUpdates.toArray(new Mutation[localUpdates.size()]));
-          }
-
+          
           // write them, either to WAL or the index tables
           doPre(indexUpdates, edit, durability);
       }

--- a/phoenix-core/src/main/java/org/apache/phoenix/util/DateUtil.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/util/DateUtil.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.TimeZone;
 
 import org.apache.commons.lang.time.FastDateFormat;
-import org.apache.hadoop.hbase.exceptions.IllegalArgumentIOException;
 import org.apache.phoenix.schema.IllegalDataException;
 import org.apache.phoenix.schema.types.PDataType;
 import org.joda.time.DateTimeZone;

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
 
   <repositories>
     <repository>
+      <id>hortonwork repo</id>
+      <name>Hortonworks Repository</name>
+      <url>http://repo.hortonworks.com/content/groups/public</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>apache release</id>
       <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>


### PR DESCRIPTION
fix for below error:
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /root/HDP_2.5/phoenix-release/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/Indexer.java:[286,26] cannot find symbol
  symbol:   method addOperationsFromCP(int,org.apache.hadoop.hbase.client.Mutation[])
  location: variable miniBatchOp of type org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress<org.apache.hadoop.hbase.client.Mutation>
[INFO] 1 error
